### PR TITLE
feat: add FileStation.downloadFile

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -124,6 +124,7 @@ export class SynologyApi extends BaseModuleSynologyApi {
       params?: Record<string, any>;
       data?: Record<string, any>;
       headers?: Record<string, any>;
+      responseType?: AxiosRequestConfig["responseType"];
     }
   ): Promise<AxiosRequestConfig> {
     if (!this.isConnecting) {
@@ -153,6 +154,7 @@ export class SynologyApi extends BaseModuleSynologyApi {
         "x-syno-token": this.authInfo.synotoken,
       },
       data: options.data ?? null,
+      responseType: options.responseType,
     };
     // https agent for node
     if (isNode) {

--- a/src/modules/FileStation/Download.ts
+++ b/src/modules/FileStation/Download.ts
@@ -25,3 +25,34 @@ export async function getDownloadFile(params: DownloadFileParams): Promise<Downl
     success: true,
   };
 }
+
+type ResponseType = "stream" | "arraybuffer" | "text" | "blob";
+
+export type FetchFileParams<T extends ResponseType> = {
+  path: string;
+  responseType: T;
+};
+
+type FetchFileResponse<T extends ResponseType> = T extends "arraybuffer"
+  ? ArrayBuffer
+  : T extends "stream"
+    ? ReadableStream
+    : T extends "blob"
+      ? Blob
+      : string;
+
+export async function downloadFile<T extends ResponseType>({
+  path,
+  responseType,
+}: FetchFileParams<T>): Promise<FetchFileResponse<T>> {
+  const api = this.getApiInfoByName(FileStationApi.Download);
+  const params = {
+    params: { method: "download", path },
+    mode: "download",
+    version: api.maxVersion,
+    api: FileStationApi.Download,
+    _sid: this.authInfo.sid,
+    responseType: responseType,
+  };
+  return this.run(FileStationApi.Download, params);
+}

--- a/src/modules/FileStation/index.base.ts
+++ b/src/modules/FileStation/index.base.ts
@@ -13,7 +13,7 @@ import {
 } from "./Favorite";
 import { startSearch, stopSearch, getSearchList, cleanSearch } from "./Search";
 import { createFolder } from "./CreateFolder";
-import { getDownloadFile } from "./Download";
+import { downloadFile, getDownloadFile } from "./Download";
 import { stopDeleteFile, startDeleteFile, getDeleteFileStatus } from "./Delete";
 import { getThumbUrl } from "./Thumb";
 import { startDirSizeCalc, stopDirSizeCalc, getDirSizeCalcStatus } from "./DirSize";
@@ -47,6 +47,7 @@ export const METHODS = {
   cleanSearch,
   createFolder,
   getDownloadFile,
+  downloadFile,
   stopDeleteFile,
   startDeleteFile,
   getDeleteFileStatus,
@@ -71,4 +72,3 @@ export const METHODS = {
   getCopyMoveStatus,
   stopCopyMove,
 };
-


### PR DESCRIPTION
The security model of Synology's web API is quite picky with its SIDs. The link created with `FileStation.getFileDownload` will not work with any fetch method but the same Axios instance that was used to connect and log in, as the SID will not be accepted.

To be able to actually fetch files from the FileStation, I added a method `FileStation.downloadFile` which lets you tell Axios how you would like the response to be shaped, defaulting to `ArrayBuffer`. By integration to the `synology-api`-object it uses the same Axios instance, thus being able to download files successfully.